### PR TITLE
Wdp190701 13

### DIFF
--- a/src/partials/30_section-features.html
+++ b/src/partials/30_section-features.html
@@ -1,7 +1,7 @@
 <div class="section--features">
   <div class="container">
     <div class="row">
-      <div class="col">
+      <div class="col-6 col-sm-6 col-md-3">
         <div class="feature-box active">
           <div class="icon"><i class="fas fa-truck"></i></div>
           <div class="content">
@@ -10,7 +10,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col-6 col-sm-6 col-md-3">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-headphones"></i></div>
           <div class="content">
@@ -19,7 +19,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col-6 col-sm-6 col-md-3">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-reply-all"></i></div>
           <div class="content">
@@ -28,7 +28,7 @@
           </div>
         </div>
       </div>
-      <div class="col">
+      <div class="col-6 col-sm-6 col-md-3">
         <div class="feature-box">
           <div class="icon"><i class="fas fa-bullhorn"></i></div>
           <div class="content">

--- a/src/sass/components/_feature-box.scss
+++ b/src/sass/components/_feature-box.scss
@@ -2,6 +2,7 @@
   border: 1px solid #b6b6b6;
   text-align: center;
   margin-top: 40px;
+  min-height: 150px;
 
   .icon {
     transform: translateY(-50%);


### PR DESCRIPTION
**Problem:** 
Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 
Ten task dotyczy kart korzyści ("Free shipping", etc.).
Klient chce w trybach tablet i mobile mieć je w 2 rzędach, po 2 elementy w każdym, ale elementy w jednym rzędzie (obok siebie) nie powinny się różnić wysokością. 

**Rozwiązanie**
- dodałam responsive grid w html'u
- ustawiłam minimalną wysokość każdego boxa na 150px;