### PR TITLE
Wdp190701 16

### DIFF
--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -2,7 +2,7 @@
   <div class="footer-menu">
     <div class="container">
       <div class="row">
-        <div class="col">
+        <div class="col-12 col-sm-6 col-md-3">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -13,7 +13,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-12 col-sm-6 col-md-3">
           <div class="menu-wrapper">
             <h6>My account</h6>
             <ul>
@@ -24,7 +24,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-12 col-sm-6 col-md-3">
           <div class="menu-wrapper">
             <h6>Information</h6>
             <ul>
@@ -35,7 +35,7 @@
             </ul>
           </div>
         </div>
-        <div class="col">
+        <div class="col-12 col-sm-6 col-md-3">
           <div class="menu-wrapper">
             <h6>Orders</h6>
             <ul>
@@ -53,11 +53,11 @@
   <div class="bottom-bar">
     <div class="container">
       <div class="row align-items-center">
-        <div class="col"></div>
-        <div class="col copyright text-center">
+        <div class="col-12 col-sm-12 col-md-4"></div>
+        <div class="col-12 col-sm-12 col-md-4 copyright text-center">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>
         </div>
-        <div class="col socialmedia text-right">
+        <div class="col-12 col-sm-12 col-md-4 socialmedia text-right">
           <ul>
             <li>
               <a href="#"><i class="fab fa-twitter"></i></a>

--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -1,5 +1,5 @@
 <footer>
-  <div class="footer-menu">
+  <div class="footer-menu text-center">
     <div class="container">
       <div class="row">
         <div class="col-12 col-sm-6 col-md-3">

--- a/src/partials/90_footer.html
+++ b/src/partials/90_footer.html
@@ -54,10 +54,10 @@
     <div class="container">
       <div class="row align-items-center">
         <div class="col-12 col-sm-12 col-md-4"></div>
-        <div class="col-12 col-sm-12 col-md-4 copyright text-center">
+        <div class="col-12 col-sm-6 col-md-4 copyright text-center">
           <p>©Copyright 2016 Bazar | All Rights Reserved</p>
         </div>
-        <div class="col-12 col-sm-12 col-md-4 socialmedia text-right">
+        <div class="col-12 col-sm-6 col-md-4 socialmedia text-right">
           <ul>
             <li>
               <a href="#"><i class="fab fa-twitter"></i></a>

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -78,3 +78,29 @@ footer {
     }
   }
 }
+
+@media (max-width: 576px) {
+  footer {
+    .footer-menu {
+      text-align: center;
+    }
+
+    .socialmedia ul {
+      text-align: center;
+    }
+  }
+}
+
+@media (min-width: 576px) and (max-width: 991px) {
+  footer {
+    .bottom-bar {
+      .copyright p {
+        text-align: left;
+      }
+
+      .socialmedia ul {
+        text-align: right;
+      }
+    }
+  }
+}

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -79,18 +79,6 @@ footer {
   }
 }
 
-@media (max-width: 576px) {
-  footer {
-    .footer-menu {
-      text-align: center;
-    }
-
-    .socialmedia ul {
-      text-align: center;
-    }
-  }
-}
-
 @media (min-width: 576px) and (max-width: 991px) {
   footer {
     .bottom-bar {


### PR DESCRIPTION
**Opis problemu:** 
Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 

Ten task dotyczy stopki (linki na szarym tle, i pod nim ciemniejszy pasek na końcu strony). 

Górna partia stopki (szare tło, linki ikony metod płatności) na tabletach się mieści, ale na mniejszych ekranach chce żeby były po dwie sekcje na szerokość, a jak w najmniejszych rozdzielczościach nie będą się mieścić, to nawet 1 na szerokość (tylko w tych najmniejszych). 

W tym dolnym pasku Klient chce żeby na tablecie copyright był do lewej, a socjalki do prawej. Tam jest obecnie specjalnie zostawione miejsce po lewej, w którym na razie niczego nie ma, ale Klient prosił o uwzględnienie że może być coś dodane i wtedy na tabletach to coś ma być wyśrodkowane i na całą szerokość (nad copyright i socjalkami). 

Rozwiązanie:
- dodałam klasy RWD z Bootsrapa do stopki (html)
- poprawiłam style (zgodnie z sugestią w kwestii tabletów + dla małych urządzeń wycentrowałam treść)